### PR TITLE
Updates assemble debug CI stage to follow JDK 11

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build
         run: ./gradlew assembleDebug


### PR DESCRIPTION
In one of my other PR targeting Compose changes would have its Lint checks fail due to our current setup using JDK 1.8
For compose to work we need AGP version 7.0.0, which enforces JDK 11 requirement

This PR updates setup for github actions JDK 11